### PR TITLE
Let format() take a language formatter class

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -653,3 +653,42 @@ $jewishDate->format()->english($options)->yomTov();  // Sukkot
 Keying by enum class matters: `MasechtaBavli` and `MasechtaYerushalmi` share many case names, so a `MasechtaYerushalmi` entry changes only the Yerushalmi output and leaves Bavli alone. Unknown enum classes and unknown case names both throw, so a misspelled case name is caught immediately.
 
 Anything you don't pass keeps its default, and you only need to include the entries you actually want to change.
+
+#### Going straight to a language formatter
+
+`format()` also accepts a language formatter class, which skips the `english()` / `hebrew()` step and hands you that formatter directly. Options go in the second argument:
+
+```php
+use PhpZmanim\JewishDate\Formatter\Hebrew;
+use PhpZmanim\JewishDate\Formatter\English;
+
+$jewishDate->format(Hebrew::class)->date();   // ט״ו תשרי תשפ״ד
+$jewishDate->format(English::class)->date();  // 15 Tishrei, 5784
+
+$jewishDate->format(Hebrew::class, ['useGershGershayim' => false])->date();  // טו תשרי תשפד
+```
+
+These are the same two calls:
+
+```php
+$jewishDate->format()->hebrew($options);
+$jewishDate->format(Hebrew::class, $options);
+```
+
+The fluent form reads better when you are writing the call by hand. The class form is for when the language is a variable — a user preference, a config value, a request parameter — and you would otherwise be branching on it:
+
+```php
+$formatter = $user->prefersHebrew ? Hebrew::class : English::class;
+
+$jewishDate->format($formatter)->date();
+$jewishDate->format($formatter)->yomTov();
+```
+
+Passing no argument still gives you the `JewishDateFormatter`, so existing code is unaffected.
+
+Anything that isn't a `LanguageFormatter` subclass throws an `InvalidArgumentException`, and option keys are validated exactly as they are on `english()` / `hebrew()`:
+
+```php
+$jewishDate->format(\DateTime::class);  // InvalidArgumentException: must be a ... LanguageFormatter subclass
+$jewishDate->format(Hebrew::class, ['useGershGershyim' => false]);  // InvalidArgumentException: Unknown formatter option
+```

--- a/src/JewishDate/Formatting.php
+++ b/src/JewishDate/Formatting.php
@@ -22,12 +22,26 @@
 
 namespace PhpZmanim\JewishDate;
 
+use InvalidArgumentException;
 use PhpZmanim\JewishDate\Formatter\JewishDateFormatter;
+use PhpZmanim\JewishDate\Formatter\LanguageFormatter;
 
 trait Formatting
 {
-	public function format(): JewishDateFormatter
+	public function format(?string $language = null, array $options = []): JewishDateFormatter|LanguageFormatter
 	{
+		if (!is_null($language)) {
+			if (!is_subclass_of($language, LanguageFormatter::class)) {
+				throw new InvalidArgumentException(sprintf(
+					'The language must be a %s subclass, e.g. Hebrew::class; got "%s".',
+					LanguageFormatter::class,
+					$language
+				));
+			}
+
+			return new $language($this, $options);
+		}
+
 		return new JewishDateFormatter($this);
 	}
 }

--- a/tests/JewishDate/FormatterOptionsTest.php
+++ b/tests/JewishDate/FormatterOptionsTest.php
@@ -24,6 +24,9 @@ use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PhpZmanim\JewishDate;
+use PhpZmanim\JewishDate\Formatter\English;
+use PhpZmanim\JewishDate\Formatter\Hebrew;
+use PhpZmanim\JewishDate\Formatter\LanguageFormatter;
 use PhpZmanim\Torah\MasechtaBavli;
 use PhpZmanim\Torah\MasechtaYerushalmi;
 use PhpZmanim\Torah\YomTov;
@@ -347,5 +350,77 @@ class FormatterOptionsTest extends TestCase
 		// a fresh formatter off the same JewishDate is unaffected
 		$this->assertSame('ט״ו תשרי תשפ״ד', $date->format()->hebrew()->date());
 		$this->assertSame('15 Tishrei, 5784', $date->format()->english()->date());
+	}
+
+	/*
+	|--------------------------------------------------------------------------
+	| SKIP FORMATTER CLASS - allow the user to give a language to get language formatter
+	|--------------------------------------------------------------------------
+	*/
+
+	#[Test]
+	public function giveLanguageToFormat(): void
+	{
+		$date = JewishDate::create(5784, 7, 15);
+		$customized = $date->format(Hebrew::class, ['useGershGershayim' => false]);
+		$this->assertSame('טו תשרי תשפד', $customized->date());
+	}
+
+	#[Test]
+	public function languageClassMatchesTheFluentForm(): void
+	{
+		$date = JewishDate::create(5784, 7, 15);
+
+		$this->assertSame($date->format()->hebrew()->date(), $date->format(Hebrew::class)->date());
+		$this->assertSame($date->format()->english()->date(), $date->format(English::class)->date());
+
+		$options = ['shabbos' => 'Shabbat'];
+		$this->assertSame(
+			$date->format()->english($options)->dayOfWeek(),
+			$date->format(English::class, $options)->dayOfWeek()
+		);
+	}
+
+	#[Test]
+	public function unknownOptionKeyStillThrowsWhenGivenALanguageClass(): void
+	{
+		$date = JewishDate::create(5784, 7, 15);
+
+		$this->expectException(InvalidArgumentException::class);
+		$this->expectExceptionMessage('Unknown formatter option: useGershGershyim');
+
+		$date->format(Hebrew::class, ['useGershGershyim' => false]);
+	}
+
+	#[Test]
+	public function classThatIsNotALanguageFormatterThrows(): void
+	{
+		$date = JewishDate::create(5784, 7, 15);
+
+		$this->expectException(InvalidArgumentException::class);
+		$this->expectExceptionMessage('must be a PhpZmanim\JewishDate\Formatter\LanguageFormatter subclass');
+
+		$date->format(DateTime::class);
+	}
+
+	#[Test]
+	public function classThatDoesNotExistThrows(): void
+	{
+		$date = JewishDate::create(5784, 7, 15);
+
+		$this->expectException(InvalidArgumentException::class);
+		$this->expectExceptionMessage('got "Nope"');
+
+		$date->format('Nope');
+	}
+
+	#[Test]
+	public function abstractLanguageFormatterThrows(): void
+	{
+		$date = JewishDate::create(5784, 7, 15);
+
+		$this->expectException(InvalidArgumentException::class);
+
+		$date->format(LanguageFormatter::class);
 	}
 }


### PR DESCRIPTION
format() now accepts a LanguageFormatter subclass and an options array, returning that formatter directly instead of requiring the ->hebrew() / ->english() step. Useful when the language is a variable rather than something typed by hand.

The class argument is validated, so passing a non-LanguageFormatter throws an InvalidArgumentException rather than failing somewhere inside an unrelated constructor. Option keys are still validated as before.

Passing no argument returns a JewishDateFormatter as it always has.